### PR TITLE
UI Feedback

### DIFF
--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -17,10 +17,18 @@ class _ParentHomeState extends State<ParentHome> {
   String? errorMessage;
   bool loading = true;
 
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
     _getParents();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   void _getParents() async {
@@ -158,6 +166,7 @@ class _ParentHomeState extends State<ParentHome> {
           .toList();
 
       body = ListView(
+        controller: _scrollController,
         children: [
           outstandingCards.isEmpty
               ? const SizedBox.shrink()

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -93,19 +93,33 @@ class _ParentHomeState extends State<ParentHome> {
                 subtitle: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Row(
-                      children: [
-                        Icon(Icons.email_rounded, size: 14.0),
-                        SizedBox(width: 4.0),
-                        Text(e.email),
-                      ],
+                    Flexible(
+                      child: Row(
+                        children: [
+                          Icon(Icons.email_rounded, size: 14.0),
+                          SizedBox(width: 4.0),
+                          Expanded(
+                              child: Text(
+                            e.email,
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: false,
+                          )),
+                        ],
+                      ),
                     ),
-                    Row(
-                      children: [
-                        Icon(Icons.phone, size: 14.0),
-                        SizedBox(width: 4.0),
-                        Text(e.phone),
-                      ],
+                    Flexible(
+                      child: Row(
+                        children: [
+                          Icon(Icons.phone, size: 14.0),
+                          SizedBox(width: 4.0),
+                          Expanded(
+                              child: Text(
+                            e.phone,
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: false,
+                          )),
+                        ],
+                      ),
                     ),
                   ],
                 ),

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -160,13 +160,16 @@ class _ParentDetailsState extends State<ParentDetails> {
           const SizedBox(height: 8),
           UnpaidEventsTable(parent: parent),
           const SizedBox(height: 8),
-          Card(
-            child: ListTile(
-              title: Text('Send registered events reminder'),
-              trailing: Icon(Icons.send),
-              onTap: () {
-                client.parent.remindParent(parent.id!);
-              },
+          ElevatedButton(
+            onPressed: () {
+              client.parent.remindParent(parent.id!);
+            },
+            child: const Row(
+              children: [
+                Text('Send registered events reminder'),
+                Spacer(),
+                Icon(Icons.send),
+              ],
             ),
           ),
         ],

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -137,7 +137,7 @@ class _ParentDetailsState extends State<ParentDetails> {
           ),
           Row(
             children: [
-              Text('Balance:',
+              Text('Credit:',
                   style: const TextStyle(
                       fontSize: 16, fontWeight: FontWeight.bold)),
               const SizedBox(width: 8),
@@ -145,7 +145,7 @@ class _ParentDetailsState extends State<ParentDetails> {
             ],
           ),
           const SizedBox(height: 16),
-          const Text('Transaction History:',
+          const Text('Payment History:',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           ParentTransactionTable(

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -68,6 +68,8 @@ class _ParentDetailsState extends State<ParentDetails> {
       body = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          Text('Parent Details:', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
           Row(
             children: [
               Text('Email:',
@@ -114,25 +116,25 @@ class _ParentDetailsState extends State<ParentDetails> {
             ],
           ),
           const SizedBox(height: 8),
-          Row(
+            Wrap(
             children: [
               Text('Children:',
-                  style: const TextStyle(
-                      fontSize: 16, fontWeight: FontWeight.bold)),
+                style: const TextStyle(
+                  fontSize: 16, fontWeight: FontWeight.bold)),
               ...children.map((child) => TextButton(
-                    style: TextButton.styleFrom(
-                      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-                      minimumSize: Size(0, 0),
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    onPressed: () => {
-                      Navigator.of(context)
-                          .push(MaterialPageRoute(builder: (context) {
-                        return ScoutDetailsView(scoutId: child.id!);
-                      })),
-                    },
-                    child: Text(child.fullName),
-                  )),
+                style: TextButton.styleFrom(
+                  padding: EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                  minimumSize: Size(0, 0),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () => {
+                  Navigator.of(context)
+                    .push(MaterialPageRoute(builder: (context) {
+                  return ScoutDetailsView(scoutId: child.id!);
+                  })),
+                },
+                child: Text(child.fullName),
+                )),
             ],
           ),
           Row(

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -157,12 +157,14 @@ class _ParentDetailsState extends State<ParentDetails> {
           const SizedBox(height: 8),
           UnpaidEventsTable(parent: parent),
           const SizedBox(height: 8),
-          TextButton.icon(
-            icon: Icon(Icons.send),
-            label: Text('Send registered events reminder'),
-            onPressed: () {
-              client.parent.remindParent(parent.id!);
-            },
+          Card(
+            child: ListTile(
+              title: Text('Send registered events reminder'),
+              trailing: Icon(Icons.send),
+              onTap: () {
+                client.parent.remindParent(parent.id!);
+              },
+            ),
           ),
         ],
       );

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -68,7 +68,8 @@ class _ParentDetailsState extends State<ParentDetails> {
       body = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Parent Details:', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          Text('Parent Details:',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           Row(
             children: [
@@ -116,25 +117,25 @@ class _ParentDetailsState extends State<ParentDetails> {
             ],
           ),
           const SizedBox(height: 8),
-            Wrap(
+          Wrap(
             children: [
               Text('Children:',
-                style: const TextStyle(
-                  fontSize: 16, fontWeight: FontWeight.bold)),
+                  style: const TextStyle(
+                      fontSize: 16, fontWeight: FontWeight.bold)),
               ...children.map((child) => TextButton(
-                style: TextButton.styleFrom(
-                  padding: EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-                  minimumSize: Size(0, 0),
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                onPressed: () => {
-                  Navigator.of(context)
-                    .push(MaterialPageRoute(builder: (context) {
-                  return ScoutDetailsView(scoutId: child.id!);
-                  })),
-                },
-                child: Text(child.fullName),
-                )),
+                    style: TextButton.styleFrom(
+                      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                      minimumSize: Size(0, 0),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    onPressed: () => {
+                      Navigator.of(context)
+                          .push(MaterialPageRoute(builder: (context) {
+                        return ScoutDetailsView(scoutId: child.id!);
+                      })),
+                    },
+                    child: Text(child.fullName),
+                  )),
             ],
           ),
           Row(

--- a/scouts_finances_flutter/lib/payments/home.dart
+++ b/scouts_finances_flutter/lib/payments/home.dart
@@ -27,8 +27,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
       final matchedPayments = result.where((p) => p.parent != null).toList();
       matchedPayments.sort((a, b) => a.date.compareTo(b.date));
 
-      final unmatchedPayments =
-          result.where((p) => p.parent == null).toList();
+      final unmatchedPayments = result.where((p) => p.parent == null).toList();
       unmatchedPayments.sort((a, b) => a.date.compareTo(b.date));
 
       setState(() {
@@ -86,8 +85,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
             payment.date.toLocal().toString().contains(query))
         .toList();
 
-    List<Card> matchedPaymentCards =
-        filteredMatchedPayments.map((payment) {
+    List<Card> matchedPaymentCards = filteredMatchedPayments.map((payment) {
       return toCard(context, payment);
     }).toList();
 
@@ -110,8 +108,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
 
     if (uncmatchedPaymentCards.isNotEmpty) {
       body.add(ExpansionTile(
-          title: Text(
-              'Unmatched Payments - ${uncmatchedPaymentCards.length}'),
+          title: Text('Unmatched Payments - ${uncmatchedPaymentCards.length}'),
           initiallyExpanded: true,
           controlAffinity: ListTileControlAffinity.leading,
           shape: const Border(),

--- a/scouts_finances_flutter/lib/payments/home.dart
+++ b/scouts_finances_flutter/lib/payments/home.dart
@@ -14,8 +14,8 @@ class PaymentsHome extends StatefulWidget {
 }
 
 class _PaymentsHomeState extends State<PaymentsHome> {
-  late List<Payment> classifiedPayments;
-  late List<Payment> unclassifiedPayments;
+  late List<Payment> matchedPayments;
+  late List<Payment> unmatchedPayments;
   String? err;
   bool loading = true;
   String query = '';
@@ -24,16 +24,16 @@ class _PaymentsHomeState extends State<PaymentsHome> {
     try {
       final result = await client.payment.getPayments();
 
-      final classifiedPayments = result.where((p) => p.parent != null).toList();
-      classifiedPayments.sort((a, b) => a.date.compareTo(b.date));
+      final matchedPayments = result.where((p) => p.parent != null).toList();
+      matchedPayments.sort((a, b) => a.date.compareTo(b.date));
 
-      final unclassifiedPayments =
+      final unmatchedPayments =
           result.where((p) => p.parent == null).toList();
-      unclassifiedPayments.sort((a, b) => a.date.compareTo(b.date));
+      unmatchedPayments.sort((a, b) => a.date.compareTo(b.date));
 
       setState(() {
-        this.classifiedPayments = classifiedPayments;
-        this.unclassifiedPayments = unclassifiedPayments;
+        this.matchedPayments = matchedPayments;
+        this.unmatchedPayments = unmatchedPayments;
         loading = false;
       });
     } catch (e) {
@@ -66,28 +66,28 @@ class _PaymentsHomeState extends State<PaymentsHome> {
     }
 
     // Filter payments based on the search query
-    List<Payment> filteredUnclassifiedPayments = unclassifiedPayments
+    List<Payment> filteredUnmatchedPayments = unmatchedPayments
         .where((payment) =>
             payment.payee.toLowerCase().contains(query.toLowerCase()) ||
             (payment.amount / 100).toString().contains(query) ||
             payment.date.toLocal().toString().contains(query))
         .toList();
 
-    List<Card> unclassifiedPaymentCards =
-        filteredUnclassifiedPayments.map((payment) {
+    List<Card> uncmatchedPaymentCards =
+        filteredUnmatchedPayments.map((payment) {
       return toCard(context, payment);
     }).toList();
 
     // Filter payments based on the search query
-    List<Payment> filteredClassifiedPayments = classifiedPayments
+    List<Payment> filteredMatchedPayments = matchedPayments
         .where((payment) =>
             payment.payee.toLowerCase().contains(query.toLowerCase()) ||
             payment.amount.toString().contains(query) ||
             payment.date.toLocal().toString().contains(query))
         .toList();
 
-    List<Card> classifiedPaymentCards =
-        filteredClassifiedPayments.map((payment) {
+    List<Card> matchedPaymentCards =
+        filteredMatchedPayments.map((payment) {
       return toCard(context, payment);
     }).toList();
 
@@ -108,22 +108,22 @@ class _PaymentsHomeState extends State<PaymentsHome> {
       searchBar,
     ];
 
-    if (unclassifiedPaymentCards.isNotEmpty) {
+    if (uncmatchedPaymentCards.isNotEmpty) {
       body.add(ExpansionTile(
           title: Text(
-              'Unclassified Payments - ${unclassifiedPaymentCards.length}'),
+              'Unmatched Payments - ${uncmatchedPaymentCards.length}'),
           initiallyExpanded: true,
           controlAffinity: ListTileControlAffinity.leading,
           shape: const Border(),
-          children: unclassifiedPaymentCards));
+          children: uncmatchedPaymentCards));
     }
 
-    if (classifiedPaymentCards.isNotEmpty) {
+    if (matchedPaymentCards.isNotEmpty) {
       body.add(ExpansionTile(
-          title: Text('Classified Payments - ${classifiedPaymentCards.length}'),
+          title: Text('Matched Payments - ${matchedPaymentCards.length}'),
           initiallyExpanded: false,
           shape: const Border(),
-          children: classifiedPaymentCards));
+          children: matchedPaymentCards));
     }
 
     body.add(const SizedBox(height: 128.0));
@@ -169,7 +169,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
             children: [
               const Icon(Icons.person, size: 14.0),
               const SizedBox(width: 4.0),
-              Text(payment.parent?.fullName ?? 'Unclassified'),
+              Text(payment.parent?.fullName ?? 'Unmatched'),
             ],
           ),
           const Spacer(),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scouts_finances_client/scouts_finances_client.dart';
+import 'package:scouts_finances_flutter/extensions/name.dart';
 import 'package:scouts_finances_flutter/main.dart';
 import 'package:scouts_finances_flutter/payments/payment_table.dart';
 import 'package:scouts_finances_flutter/shared/parent_dropdown.dart';
@@ -201,7 +202,13 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           const SizedBox(height: 16),
           ElevatedButton(
             onPressed: submit,
-            child: Text('Classify Payment'),
+            child: Row(
+              children: [
+                Text('Match payment to ${currParent.fullName}'),
+                Spacer(),
+                Icon(Icons.check_rounded),
+              ],
+            ),
           ),
         ],
       );
@@ -209,7 +216,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Classify Payment'),
+        title: const Text('Match Payment'),
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -98,7 +98,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
               "No parents found. This suggests there is an internal error. Please contact the developers."));
     } else {
       Row parentSelection = Row(children: [
-        Text("Match this payment to parent: ", style:  TextStyle(fontSize: 16)),
+        Text("Match this payment to parent: ", style: TextStyle(fontSize: 16)),
         ParentDropdown(
           parents: parents,
           defaultParentId: parents[parentIndex].id,
@@ -134,7 +134,9 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
       if (toBePaidEvents.isNotEmpty) {
         clearedEventsInfo.add(const Text(
           "This payment will mark the following events as paid:",
-          style: TextStyle(fontSize: 16,),
+          style: TextStyle(
+            fontSize: 16,
+          ),
         ));
         clearedEventsInfo.add(Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -166,7 +168,9 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                               DataCell(Text(
                                   '${event.child!.firstName} ${event.child!.lastName}')),
                               DataCell(Text(event.event!.name)),
-                              DataCell(Text(formatMoney(event.event!.cost), style: TextStyle(fontWeight: FontWeight.bold))),
+                              DataCell(Text(formatMoney(event.event!.cost),
+                                  style:
+                                      TextStyle(fontWeight: FontWeight.bold))),
                             ],
                           ),
                         )
@@ -202,25 +206,31 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           PaymentTable(payment: payment!),
           const SizedBox(height: 16),
           Column(children: [parentSelection]),
-          ElevatedButton(child: Row(
-            children: [
-              Text('See ${parents[parentIndex].firstName}\'s details and payment history'),
-              Spacer(),
-              Icon(Icons.arrow_forward_rounded),
-            ],
-          ), onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => ParentDetails(parentId: currParent.id!),
-              ),
-            );
-          },),
+          ElevatedButton(
+            child: Row(
+              children: [
+                Text(
+                    'See ${parents[parentIndex].firstName}\'s details and payment history'),
+                Spacer(),
+                Icon(Icons.arrow_forward_rounded),
+              ],
+            ),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => ParentDetails(parentId: currParent.id!),
+                ),
+              );
+            },
+          ),
           const SizedBox(height: 16),
           RichText(
             text: TextSpan(
               style: const TextStyle(fontSize: 16, color: Colors.black),
               children: [
-                TextSpan(text: "This will change ${currParent.firstName}'s balance from "),
+                TextSpan(
+                    text:
+                        "This will change ${currParent.firstName}'s balance from "),
                 TextSpan(
                   text: formatMoney(currParent.balance),
                   style: const TextStyle(fontWeight: FontWeight.bold),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -196,7 +196,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
         ));
       }
 
-      body = Column(
+      body = ListView(
         children: [
           PaymentTable(payment: payment!),
           const SizedBox(height: 16),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:scouts_finances_client/scouts_finances_client.dart';
 import 'package:scouts_finances_flutter/extensions/name.dart';
 import 'package:scouts_finances_flutter/main.dart';
+import 'package:scouts_finances_flutter/parents/parent_details.dart';
 import 'package:scouts_finances_flutter/payments/payment_table.dart';
 import 'package:scouts_finances_flutter/shared/parent_dropdown.dart';
 
@@ -201,7 +202,20 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           PaymentTable(payment: payment!),
           const SizedBox(height: 16),
           Column(children: [parentSelection]),
-          const SizedBox(height: 32),
+          ElevatedButton(child: Row(
+            children: [
+              Text('See ${parents[parentIndex].firstName}\'s details and payment history'),
+              Spacer(),
+              Icon(Icons.arrow_forward_rounded),
+            ],
+          ), onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => ParentDetails(parentId: currParent.id!),
+              ),
+            );
+          },),
+          const SizedBox(height: 16),
           RichText(
             text: TextSpan(
               style: const TextStyle(fontSize: 16, color: Colors.black),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -161,7 +161,9 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                             (event) => DataRow(
                               cells: [
                                 DataCell(Text(
-                                  event.event!.date.toIso8601String().split('T')[0],
+                                  event.event!.date
+                                      .toIso8601String()
+                                      .split('T')[0],
                                 )),
                                 DataCell(Text(
                                     '${event.child!.firstName} ${event.child!.lastName}')),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -97,7 +97,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
               "No parents found. This suggests there is an internal error. Please contact the developers."));
     } else {
       Row parentSelection = Row(children: [
-        Text("Assign this payment to parent: "),
+        Text("Match this payment to parent: ", style:  TextStyle(fontSize: 16)),
         ParentDropdown(
           parents: parents,
           defaultParentId: parents[parentIndex].id,
@@ -133,54 +133,59 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
       if (toBePaidEvents.isNotEmpty) {
         clearedEventsInfo.add(const Text(
           "This payment will mark the following events as paid:",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          style: TextStyle(fontSize: 16,),
         ));
         clearedEventsInfo.add(Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Container(
-              alignment: Alignment.topCenter,
-              constraints: const BoxConstraints(maxHeight: 200),
-              child: Scrollbar(
-                thumbVisibility: true,
+            Scrollbar(
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.vertical,
                 child: SingleChildScrollView(
-                  scrollDirection: Axis.vertical,
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.only(right: 16.0),
-                    scrollDirection: Axis.horizontal,
-                    child: DataTable(
-                      columnSpacing: 24.0,
-                      columns: const [
-                        DataColumn(label: Text('Date')),
-                        DataColumn(label: Text('Child')),
-                        DataColumn(label: Text('Event')),
-                        DataColumn(label: Text('Cost (£)')),
-                      ],
-                      rows: toBePaidEvents
-                          .map(
-                            (event) => DataRow(
-                              cells: [
-                                DataCell(Text(
-                                  event.event!.date
-                                      .toIso8601String()
-                                      .split('T')[0],
-                                )),
-                                DataCell(Text(
-                                    '${event.child!.firstName} ${event.child!.lastName}')),
-                                DataCell(Text(event.event!.name)),
-                                DataCell(Text(formatMoney(event.event!.cost))),
-                              ],
-                            ),
-                          )
-                          .toList(),
-                    ),
+                  padding: const EdgeInsets.only(right: 16.0),
+                  scrollDirection: Axis.horizontal,
+                  child: DataTable(
+                    columnSpacing: 24.0,
+                    columns: const [
+                      DataColumn(label: Text('Date')),
+                      DataColumn(label: Text('Child')),
+                      DataColumn(label: Text('Event')),
+                      DataColumn(label: Text('Cost (£)')),
+                    ],
+                    rows: toBePaidEvents
+                        .map(
+                          (event) => DataRow(
+                            cells: [
+                              DataCell(Text(
+                                event.event!.date
+                                    .toIso8601String()
+                                    .split('T')[0],
+                              )),
+                              DataCell(Text(
+                                  '${event.child!.firstName} ${event.child!.lastName}')),
+                              DataCell(Text(event.event!.name)),
+                              DataCell(Text(formatMoney(event.event!.cost), style: TextStyle(fontWeight: FontWeight.bold))),
+                            ],
+                          ),
+                        )
+                        .toList(),
                   ),
                 ),
               ),
             ),
-            Text(
-              'Leaving a balance of ${formatMoney(bal)}.',
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            RichText(
+              text: TextSpan(
+                style: const TextStyle(fontSize: 16, color: Colors.black),
+                children: [
+                  const TextSpan(text: 'Leaving a balance of '),
+                  TextSpan(
+                    text: formatMoney(bal),
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const TextSpan(text: '.'),
+                ],
+              ),
             ),
           ],
         ));
@@ -197,9 +202,24 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           const SizedBox(height: 16),
           Column(children: [parentSelection]),
           const SizedBox(height: 32),
-          Text(
-              "This will change ${currParent.firstName}'s balance from ${formatMoney(currParent.balance)} to ${formatMoney(currParent.balance + payment!.amount)}.",
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+          RichText(
+            text: TextSpan(
+              style: const TextStyle(fontSize: 16, color: Colors.black),
+              children: [
+                TextSpan(text: "This will change ${currParent.firstName}'s balance from "),
+                TextSpan(
+                  text: formatMoney(currParent.balance),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const TextSpan(text: " to "),
+                TextSpan(
+                  text: formatMoney(currParent.balance + payment!.amount),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const TextSpan(text: "."),
+              ],
+            ),
+          ),
           ...clearedEventsInfo,
           const SizedBox(height: 16),
           ElevatedButton(

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -150,6 +150,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                     child: DataTable(
                       columnSpacing: 24.0,
                       columns: const [
+                        DataColumn(label: Text('Date')),
                         DataColumn(label: Text('Child')),
                         DataColumn(label: Text('Event')),
                         DataColumn(label: Text('Cost (£)')),
@@ -158,6 +159,9 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                           .map(
                             (event) => DataRow(
                               cells: [
+                                DataCell(Text(
+                                  event.event!.date.toIso8601String().split('T')[0],
+                                )),
                                 DataCell(Text(
                                     '${event.child!.firstName} ${event.child!.lastName}')),
                                 DataCell(Text(event.event!.name)),

--- a/scouts_finances_flutter/lib/scouts/events_table.dart
+++ b/scouts_finances_flutter/lib/scouts/events_table.dart
@@ -16,10 +16,20 @@ class _ChildEventsTableState extends State<ChildEventsTable> {
   late final List<EventRegistration> registrations;
   bool loading = true;
 
+  final ScrollController _horizontalScrollController =  ScrollController();
+  final ScrollController _verticalScrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
     _fetchRegistrations();
+  }
+
+  @override
+  void dispose() {
+    _horizontalScrollController.dispose();
+    _verticalScrollController.dispose();
+    super.dispose();
   }
 
   void _fetchRegistrations() async {
@@ -63,34 +73,40 @@ class _ChildEventsTableState extends State<ChildEventsTable> {
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
           child: Scrollbar(
+            controller: _verticalScrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(
+              controller: _verticalScrollController,
               scrollDirection: Axis.vertical,
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.only(right: 16.0),
-                scrollDirection: Axis.horizontal,
-                child: DataTable(
-                  columnSpacing: 24.0,
-                  columns: const [
-                    DataColumn(label: Text('Date')),
-                    DataColumn(label: Text('Event')),
-                    DataColumn(label: Text('Amount (£)')),
-                  ],
-                  rows: registrations
-                      .map(
-                        (r) => DataRow(
-                          cells: [
-                            DataCell(Text(r.event!.date
-                                .toLocal()
-                                .toIso8601String()
-                                .split('T')[0])),
-                            DataCell(Text(r.event!.name)),
-                            DataCell(
-                                Text((r.event!.cost / 100).toStringAsFixed(2))),
-                          ],
-                        ),
-                      )
-                      .toList(),
+              child: Scrollbar(
+                controller: _horizontalScrollController,
+                child: SingleChildScrollView(
+                  controller: _horizontalScrollController,
+                  padding: const EdgeInsets.only(right: 16.0),
+                  scrollDirection: Axis.horizontal,
+                  child: DataTable(
+                    columnSpacing: 24.0,
+                    columns: const [
+                      DataColumn(label: Text('Date')),
+                      DataColumn(label: Text('Event')),
+                      DataColumn(label: Text('Amount (£)')),
+                    ],
+                    rows: registrations
+                        .map(
+                          (r) => DataRow(
+                            cells: [
+                              DataCell(Text(r.event!.date
+                                  .toLocal()
+                                  .toIso8601String()
+                                  .split('T')[0])),
+                              DataCell(Text(r.event!.name)),
+                              DataCell(
+                                  Text((r.event!.cost / 100).toStringAsFixed(2))),
+                            ],
+                          ),
+                        )
+                        .toList(),
+                  ),
                 ),
               ),
             ),

--- a/scouts_finances_flutter/lib/scouts/events_table.dart
+++ b/scouts_finances_flutter/lib/scouts/events_table.dart
@@ -16,7 +16,7 @@ class _ChildEventsTableState extends State<ChildEventsTable> {
   late final List<EventRegistration> registrations;
   bool loading = true;
 
-  final ScrollController _horizontalScrollController =  ScrollController();
+  final ScrollController _horizontalScrollController = ScrollController();
   final ScrollController _verticalScrollController = ScrollController();
 
   @override
@@ -100,8 +100,8 @@ class _ChildEventsTableState extends State<ChildEventsTable> {
                                   .toIso8601String()
                                   .split('T')[0])),
                               DataCell(Text(r.event!.name)),
-                              DataCell(
-                                  Text((r.event!.cost / 100).toStringAsFixed(2))),
+                              DataCell(Text(
+                                  (r.event!.cost / 100).toStringAsFixed(2))),
                             ],
                           ),
                         )

--- a/scouts_finances_flutter/lib/scouts/scout_details.dart
+++ b/scouts_finances_flutter/lib/scouts/scout_details.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:scouts_finances_client/scouts_finances_client.dart';
 import 'package:scouts_finances_flutter/extensions/name.dart';
 import 'package:scouts_finances_flutter/main.dart';
+import 'package:scouts_finances_flutter/parents/parent_details.dart';
 import 'package:scouts_finances_flutter/scouts/events_table.dart';
 
 class ScoutDetailsView extends StatefulWidget {
@@ -60,35 +61,49 @@ class _ScoutDetailsViewState extends State<ScoutDetailsView> {
       Text('Scout Details:',
           style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
       const SizedBox(height: 8),
-      Table(
-        columnWidths: {
-          0: IntrinsicColumnWidth(),
-        },
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          TableRow(children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child:
+          Expanded(
+            child: Table(
+              columnWidths: {
+                0: IntrinsicColumnWidth(),
+              },
+              children: [
+                TableRow(children: [
                   Text("Name", style: TextStyle(fontWeight: FontWeight.bold)),
-            ),
-            Text(scout.fullName),
-          ]),
-          TableRow(children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child:
+                  Text(scout.fullName),
+                ]),
+                TableRow(children: [
                   Text("Parent", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        padding: EdgeInsets.symmetric(horizontal: 8.0),
+                        minimumSize: Size.zero,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      onPressed: () => {
+                        Navigator.of(context)
+                            .push(MaterialPageRoute(builder: (context) {
+                          return ParentDetails(parentId: scout.parentId);
+                        })),
+                      },
+                      child: Text(scout.parent!.fullName),
+                    ),
+                  ),
+                ]),
+                TableRow(children: [
+                  Text("Group", style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text(scout.scoutGroup?.name ?? "N/A"),
+                ]),
+              ],
             ),
-            Text(scout.parent?.fullName ?? "N/A"),
-          ]),
-          TableRow(children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: Text("Group",
-                  style: TextStyle(fontWeight: FontWeight.bold)),
-            ),
-            Text(scout.scoutGroup?.name ?? "N/A"),
-          ]),
+          ),
+          const Icon(Icons.account_circle, size: 75, color: Colors.blue),
+          const SizedBox(width: 16),
         ],
       ),
       const SizedBox(height: 16),

--- a/scouts_finances_flutter/lib/scouts/scout_details.dart
+++ b/scouts_finances_flutter/lib/scouts/scout_details.dart
@@ -57,6 +57,9 @@ class _ScoutDetailsViewState extends State<ScoutDetailsView> {
     }
 
     final body = ListView(children: [
+      Text('Scout Details:',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+      const SizedBox(height: 8),
       Table(
         columnWidths: {
           0: IntrinsicColumnWidth(),
@@ -78,13 +81,21 @@ class _ScoutDetailsViewState extends State<ScoutDetailsView> {
             ),
             Text(scout.parent?.fullName ?? "N/A"),
           ]),
+          TableRow(children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text("Group",
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+            ),
+            Text(scout.scoutGroup?.name ?? "N/A"),
+          ]),
         ],
       ),
       const SizedBox(height: 16),
       Text(
-        "Subscribed Events",
+        "Subscribed Events:",
         style: TextStyle(
-          fontSize: 20,
+          fontSize: 18,
           fontWeight: FontWeight.bold,
         ),
       ),

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -16,10 +16,18 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
   late final List<Transaction> transactions;
   bool loading = true;
 
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
     _fetchTransactions();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   void _fetchTransactions() async {
@@ -95,8 +103,10 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
           child: Scrollbar(
+            controller: _scrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(
+              controller: _scrollController,
               scrollDirection: Axis.vertical,
               child: SingleChildScrollView(
                 padding: const EdgeInsets.only(right: 16.0),

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -16,7 +16,8 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
   late final List<Transaction> transactions;
   bool loading = true;
 
-  final ScrollController _scrollController = ScrollController();
+  final ScrollController _verticalScrollController = ScrollController();
+  final ScrollController _horizontalScrollController = ScrollController();
 
   @override
   void initState() {
@@ -26,7 +27,8 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
 
   @override
   void dispose() {
-    _scrollController.dispose();
+    _verticalScrollController.dispose();
+    _horizontalScrollController.dispose();
     super.dispose();
   }
 
@@ -102,36 +104,40 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
       children: [
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
-          child: Scrollbar(
-            controller: _scrollController,
+          child: Scrollbar( // Vertical scrollbar
+            controller: _verticalScrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(
-              controller: _scrollController,
+              controller: _verticalScrollController,
               scrollDirection: Axis.vertical,
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.only(right: 16.0),
-                scrollDirection: Axis.horizontal,
-                child: DataTable(
-                  columnSpacing: 24.0,
-                  columns: const [
-                    DataColumn(label: Text('Date')),
-                    DataColumn(label: Text('Description')),
-                    DataColumn(label: Text('Amount (£)')),
-                  ],
-                  rows: transactions
-                      .map(
-                        (tx) => DataRow(
-                          cells: [
-                            DataCell(Text(tx.date
-                                .toLocal()
-                                .toIso8601String()
-                                .split('T')[0])),
-                            DataCell(Text(tx.description)),
-                            DataCell(Text(tx.amount.toStringAsFixed(2))),
-                          ],
-                        ),
-                      )
-                      .toList(),
+              child: Scrollbar( // Horizontal scrollbar
+                controller: _horizontalScrollController,
+                child: SingleChildScrollView(
+                  controller: _horizontalScrollController,
+                  padding: const EdgeInsets.only(right: 16.0),
+                  scrollDirection: Axis.horizontal,
+                  child: DataTable(
+                    columnSpacing: 24.0,
+                    columns: const [
+                      DataColumn(label: Text('Date')),
+                      DataColumn(label: Text('Description')),
+                      DataColumn(label: Text('Amount (£)')),
+                    ],
+                    rows: transactions
+                        .map(
+                          (tx) => DataRow(
+                            cells: [
+                              DataCell(Text(tx.date
+                                  .toLocal()
+                                  .toIso8601String()
+                                  .split('T')[0])),
+                              DataCell(Text(tx.description)),
+                              DataCell(Text(tx.amount.toStringAsFixed(2))),
+                            ],
+                          ),
+                        )
+                        .toList(),
+                  ),
                 ),
               ),
             ),

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -104,7 +104,8 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
       children: [
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
-          child: Scrollbar( // Vertical scrollbar
+          child: Scrollbar(
+            // Vertical scrollbar
             controller: _verticalScrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -110,34 +110,31 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
             child: SingleChildScrollView(
               controller: _verticalScrollController,
               scrollDirection: Axis.vertical,
-              child: Scrollbar( // Horizontal scrollbar
+              child: SingleChildScrollView(
                 controller: _horizontalScrollController,
-                child: SingleChildScrollView(
-                  controller: _horizontalScrollController,
-                  padding: const EdgeInsets.only(right: 16.0),
-                  scrollDirection: Axis.horizontal,
-                  child: DataTable(
-                    columnSpacing: 24.0,
-                    columns: const [
-                      DataColumn(label: Text('Date')),
-                      DataColumn(label: Text('Description')),
-                      DataColumn(label: Text('Amount (£)')),
-                    ],
-                    rows: transactions
-                        .map(
-                          (tx) => DataRow(
-                            cells: [
-                              DataCell(Text(tx.date
-                                  .toLocal()
-                                  .toIso8601String()
-                                  .split('T')[0])),
-                              DataCell(Text(tx.description)),
-                              DataCell(Text(tx.amount.toStringAsFixed(2))),
-                            ],
-                          ),
-                        )
-                        .toList(),
-                  ),
+                padding: const EdgeInsets.only(right: 16.0),
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columnSpacing: 24.0,
+                  columns: const [
+                    DataColumn(label: Text('Date')),
+                    DataColumn(label: Text('Description')),
+                    DataColumn(label: Text('Amount (£)')),
+                  ],
+                  rows: transactions
+                      .map(
+                        (tx) => DataRow(
+                          cells: [
+                            DataCell(Text(tx.date
+                                .toLocal()
+                                .toIso8601String()
+                                .split('T')[0])),
+                            DataCell(Text(tx.description)),
+                            DataCell(Text(tx.amount.toStringAsFixed(2))),
+                          ],
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
             ),

--- a/scouts_finances_flutter/lib/shared/unpaid_events.dart
+++ b/scouts_finances_flutter/lib/shared/unpaid_events.dart
@@ -16,7 +16,8 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
   late final List<EventRegistration> registrations;
   bool loading = true;
 
-  final ScrollController _scrollController = ScrollController();
+  final ScrollController _verticalScrollController = ScrollController();
+  final ScrollController _horizontalScrollController = ScrollController();
 
   @override
   void initState() {
@@ -42,7 +43,8 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
 
   @override
   void dispose() {
-    _scrollController.dispose();
+    _verticalScrollController.dispose();
+    _horizontalScrollController.dispose();
     super.dispose();
   }
 
@@ -71,38 +73,42 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
           child: Scrollbar(
-            controller: _scrollController,
+            controller: _verticalScrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(
+              controller: _verticalScrollController,
               scrollDirection: Axis.vertical,
-              child: SingleChildScrollView(
-                controller: _scrollController,
-                padding: const EdgeInsets.only(right: 16.0),
-                scrollDirection: Axis.horizontal,
-                child: DataTable(
-                  columnSpacing: 24.0,
-                  columns: const [
-                    DataColumn(label: Text('Date')),
-                    DataColumn(label: Text('Event')),
-                    DataColumn(label: Text('Child')),
-                    DataColumn(label: Text('Amount (£)')),
-                  ],
-                  rows: registrations
-                      .map(
-                        (r) => DataRow(
-                          cells: [
-                            DataCell(Text(r.event!.date
-                                .toLocal()
-                                .toIso8601String()
-                                .split('T')[0])),
-                            DataCell(Text(r.event!.name)),
-                            DataCell(Text(r.child!.firstName)),
-                            DataCell(
-                                Text((r.event!.cost / 100).toStringAsFixed(2))),
-                          ],
-                        ),
-                      )
-                      .toList(),
+              child: Scrollbar(
+                controller: _horizontalScrollController,
+                child: SingleChildScrollView(
+                  controller: _horizontalScrollController,
+                  padding: const EdgeInsets.only(right: 16.0),
+                  scrollDirection: Axis.horizontal,
+                  child: DataTable(
+                    columnSpacing: 24.0,
+                    columns: const [
+                      DataColumn(label: Text('Date')),
+                      DataColumn(label: Text('Event')),
+                      DataColumn(label: Text('Child')),
+                      DataColumn(label: Text('Amount (£)')),
+                    ],
+                    rows: registrations
+                        .map(
+                          (r) => DataRow(
+                            cells: [
+                              DataCell(Text(r.event!.date
+                                  .toLocal()
+                                  .toIso8601String()
+                                  .split('T')[0])),
+                              DataCell(Text(r.event!.name)),
+                              DataCell(Text(r.child!.firstName)),
+                              DataCell(
+                                  Text((r.event!.cost / 100).toStringAsFixed(2))),
+                            ],
+                          ),
+                        )
+                        .toList(),
+                  ),
                 ),
               ),
             ),

--- a/scouts_finances_flutter/lib/shared/unpaid_events.dart
+++ b/scouts_finances_flutter/lib/shared/unpaid_events.dart
@@ -103,8 +103,8 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
                                 .split('T')[0])),
                             DataCell(Text(r.event!.name)),
                             DataCell(Text(r.child!.firstName)),
-                            DataCell(Text(
-                                (r.event!.cost / 100).toStringAsFixed(2))),
+                            DataCell(
+                                Text((r.event!.cost / 100).toStringAsFixed(2))),
                           ],
                         ),
                       )

--- a/scouts_finances_flutter/lib/shared/unpaid_events.dart
+++ b/scouts_finances_flutter/lib/shared/unpaid_events.dart
@@ -75,40 +75,40 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
           child: Scrollbar(
             controller: _verticalScrollController,
             thumbVisibility: true,
+            trackVisibility: true,
+            notificationPredicate: (ScrollNotification notification) {
+              return notification.depth == 1;
+            },
             child: SingleChildScrollView(
-              controller: _verticalScrollController,
-              scrollDirection: Axis.vertical,
-              child: Scrollbar(
-                controller: _horizontalScrollController,
-                child: SingleChildScrollView(
-                  controller: _horizontalScrollController,
-                  padding: const EdgeInsets.only(right: 16.0),
-                  scrollDirection: Axis.horizontal,
-                  child: DataTable(
-                    columnSpacing: 24.0,
-                    columns: const [
-                      DataColumn(label: Text('Date')),
-                      DataColumn(label: Text('Event')),
-                      DataColumn(label: Text('Child')),
-                      DataColumn(label: Text('Amount (£)')),
-                    ],
-                    rows: registrations
-                        .map(
-                          (r) => DataRow(
-                            cells: [
-                              DataCell(Text(r.event!.date
-                                  .toLocal()
-                                  .toIso8601String()
-                                  .split('T')[0])),
-                              DataCell(Text(r.event!.name)),
-                              DataCell(Text(r.child!.firstName)),
-                              DataCell(
-                                  Text((r.event!.cost / 100).toStringAsFixed(2))),
-                            ],
-                          ),
-                        )
-                        .toList(),
-                  ),
+              controller: _horizontalScrollController,
+              scrollDirection: Axis.horizontal,
+              child: SingleChildScrollView(
+                controller: _verticalScrollController,
+                scrollDirection: Axis.vertical,
+                child: DataTable(
+                  columnSpacing: 24.0,
+                  columns: const [
+                    DataColumn(label: Text('Date')),
+                    DataColumn(label: Text('Event')),
+                    DataColumn(label: Text('Child')),
+                    DataColumn(label: Text('Amount (£)')),
+                  ],
+                  rows: registrations
+                      .map(
+                        (r) => DataRow(
+                          cells: [
+                            DataCell(Text(r.event!.date
+                                .toLocal()
+                                .toIso8601String()
+                                .split('T')[0])),
+                            DataCell(Text(r.event!.name)),
+                            DataCell(Text(r.child!.firstName)),
+                            DataCell(Text(
+                                (r.event!.cost / 100).toStringAsFixed(2))),
+                          ],
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
             ),

--- a/scouts_finances_flutter/lib/shared/unpaid_events.dart
+++ b/scouts_finances_flutter/lib/shared/unpaid_events.dart
@@ -16,6 +16,8 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
   late final List<EventRegistration> registrations;
   bool loading = true;
 
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -36,6 +38,12 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
         loading = false;
       });
     }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -63,10 +71,12 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
           child: Scrollbar(
+            controller: _scrollController,
             thumbVisibility: true,
             child: SingleChildScrollView(
               scrollDirection: Axis.vertical,
               child: SingleChildScrollView(
+                controller: _scrollController,
                 padding: const EdgeInsets.only(right: 16.0),
                 scrollDirection: Axis.horizontal,
                 child: DataTable(

--- a/scouts_finances_server/lib/src/scouts.dart
+++ b/scouts_finances_server/lib/src/scouts.dart
@@ -16,6 +16,6 @@ class ScoutsEndpoint extends Endpoint {
   Future<Child?> getChildById(Session session, int id) async {
     // Fetch a specific child by ID
     return await Child.db.findById(session, id,
-        include: Child.include(parent: Parent.include()));
+        include: Child.include(parent: Parent.include(), scoutGroup: ScoutGroup.include()));
   }
 }

--- a/scouts_finances_server/lib/src/scouts.dart
+++ b/scouts_finances_server/lib/src/scouts.dart
@@ -16,6 +16,7 @@ class ScoutsEndpoint extends Endpoint {
   Future<Child?> getChildById(Session session, int id) async {
     // Fetch a specific child by ID
     return await Child.db.findById(session, id,
-        include: Child.include(parent: Parent.include(), scoutGroup: ScoutGroup.include()));
+        include: Child.include(
+            parent: Parent.include(), scoutGroup: ScoutGroup.include()));
   }
 }


### PR DESCRIPTION
Implement a lot of the feedback received from our Milestone interview, as well as other outstanding errors/inconsistencies.
## Parent Details
* Parent cards subtitles were overflowing - this is now fixed by truncating the email text (who cares if it's outlook or gmail anyway)
* Tables on the parent details page (unpaid events and history) now create (and `.dispose`) their own `ScrollController`s instead of using the `PrimaryController` (this was causing conflicts between horizontal and vertical scrolling). The horizontal scrollbar is now **hidden** because in the cases where it will be used the clipping should make it obvious. The vertical scrollbar is now **always shown** to make it clear that there is more content beneath the viewport.
* "Balance History" has become "Payment History" (despite the fact that it shows events too; a different name would be welcome). "Balance" has become "Credit" to emphasise that this is the sum of money not gone towards paying for an event yet. 
* "Send registered events reminder" changed to become a more obvious button
* When someone has many many children they now wrap onto the next line rather than causing overflow issues and clipping

## Child Details
* The group they are part of (scouts, beavers, cubs) now appears on the details
* There is a placeholder for profile images - I think this could help the admin remember in their head who is who but would appreciate feedback on this
* We can now navigate to the parent details by pressing on the parent's name in the details

## Payment Details
* Add date of event when listing events which would be marked as paid
* We now talk about "matching" payments rather than classifying. I hope this makes it more clear.
* General UI improvements like changing bold text, removing height constraints
* Button to reach the chosen parent's details page