### PR TITLE
feat: people page

### DIFF
--- a/scouts_finances_client/lib/src/protocol/parent.dart
+++ b/scouts_finances_client/lib/src/protocol/parent.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'child.dart' as _i2;
 
 abstract class Parent implements _i1.SerializableModel {
   Parent._({
@@ -19,6 +20,7 @@ abstract class Parent implements _i1.SerializableModel {
     required this.email,
     required this.phone,
     required this.balance,
+    this.children,
   });
 
   factory Parent({
@@ -28,6 +30,7 @@ abstract class Parent implements _i1.SerializableModel {
     required String email,
     required String phone,
     required int balance,
+    List<_i2.Child>? children,
   }) = _ParentImpl;
 
   factory Parent.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -38,6 +41,9 @@ abstract class Parent implements _i1.SerializableModel {
       email: jsonSerialization['email'] as String,
       phone: jsonSerialization['phone'] as String,
       balance: jsonSerialization['balance'] as int,
+      children: (jsonSerialization['children'] as List?)
+          ?.map((e) => _i2.Child.fromJson((e as Map<String, dynamic>)))
+          .toList(),
     );
   }
 
@@ -56,6 +62,8 @@ abstract class Parent implements _i1.SerializableModel {
 
   int balance;
 
+  List<_i2.Child>? children;
+
   /// Returns a shallow copy of this [Parent]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
@@ -66,6 +74,7 @@ abstract class Parent implements _i1.SerializableModel {
     String? email,
     String? phone,
     int? balance,
+    List<_i2.Child>? children,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -76,6 +85,8 @@ abstract class Parent implements _i1.SerializableModel {
       'email': email,
       'phone': phone,
       'balance': balance,
+      if (children != null)
+        'children': children?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -95,6 +106,7 @@ class _ParentImpl extends Parent {
     required String email,
     required String phone,
     required int balance,
+    List<_i2.Child>? children,
   }) : super._(
           id: id,
           firstName: firstName,
@@ -102,6 +114,7 @@ class _ParentImpl extends Parent {
           email: email,
           phone: phone,
           balance: balance,
+          children: children,
         );
 
   /// Returns a shallow copy of this [Parent]
@@ -115,6 +128,7 @@ class _ParentImpl extends Parent {
     String? email,
     String? phone,
     int? balance,
+    Object? children = _Undefined,
   }) {
     return Parent(
       id: id is int? ? id : this.id,
@@ -123,6 +137,9 @@ class _ParentImpl extends Parent {
       email: email ?? this.email,
       phone: phone ?? this.phone,
       balance: balance ?? this.balance,
+      children: children is List<_i2.Child>?
+          ? children
+          : this.children?.map((e0) => e0.copyWith()).toList(),
     );
   }
 }

--- a/scouts_finances_client/lib/src/protocol/protocol.dart
+++ b/scouts_finances_client/lib/src/protocol/protocol.dart
@@ -101,6 +101,11 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i3.Child>(e)).toList()
           : null) as T;
     }
+    if (t == _i1.getType<List<_i3.Child>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i3.Child>(e)).toList()
+          : null) as T;
+    }
     if (t == _i1.getType<List<_i5.Event>?>()) {
       return (data != null
           ? (data as List).map((e) => deserialize<_i5.Event>(e)).toList()

--- a/scouts_finances_flutter/lib/main.dart
+++ b/scouts_finances_flutter/lib/main.dart
@@ -5,7 +5,6 @@ import 'package:scouts_finances_flutter/events/home.dart';
 import 'package:scouts_finances_flutter/parents/home.dart';
 import 'package:scouts_finances_flutter/payments/home.dart';
 import 'package:scouts_finances_flutter/popups.dart';
-import 'package:scouts_finances_flutter/scouts/home.dart';
 import 'package:scouts_finances_flutter/services/scout_groups_service.dart';
 import 'package:scouts_finances_flutter/settings/home.dart';
 import 'package:scouts_finances_flutter/services/theme_service.dart';
@@ -80,15 +79,15 @@ class _HomePageState extends State<HomePage> {
   static final List<Widget> pages = [
     EventHome(),
     PaymentsHome(),
-    ScoutsHome(),
+    // ScoutsHome(),
     ParentHome(),
     SettingsHome()
   ];
   static final List<String> pageTitles = [
     'Events',
     'Income',
-    'Scouts',
-    'Parents',
+    // 'Scouts',
+    'People',
   ];
 
   static final List<NavigationDestination> destinations = [
@@ -100,13 +99,13 @@ class _HomePageState extends State<HomePage> {
       icon: Icon(Icons.currency_pound),
       label: 'Income',
     ),
-    const NavigationDestination(
-      icon: Icon(Icons.hiking),
-      label: 'Scouts',
-    ),
+    // const NavigationDestination(
+    //   icon: Icon(Icons.hiking),
+    //   label: 'Scouts',
+    // ),
     const NavigationDestination(
       icon: Icon(Icons.supervisor_account),
-      label: 'Parents',
+      label: 'People',
     ),
   ];
 

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -82,14 +82,15 @@ class _ParentHomeState extends State<ParentHome> {
       );
     } else {
       SearchBar searchBar = SearchBar(
-          hintText: 'Search parent, scout, email, phone',
-          onChanged: (value) => setState(() {
-                query = value;
-              }),
-          leading: Padding(
-            padding: const EdgeInsets.only(left: 8.0),
-            child: const Icon(Icons.search),
-          ),);
+        hintText: 'Search parent, scout, email, phone',
+        onChanged: (value) => setState(() {
+          query = value;
+        }),
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 8.0),
+          child: const Icon(Icons.search),
+        ),
+      );
 
       List<Widget> parentCards = allParents
           .where((e) =>
@@ -216,7 +217,7 @@ class _ParentHomeState extends State<ParentHome> {
             ),
           )
           .toList();
-      
+
       final switchWidget = SwitchListTile(
         title: const Text('Show Scouts'),
         value: showScouts,
@@ -234,7 +235,8 @@ class _ParentHomeState extends State<ParentHome> {
               ? const SizedBox.shrink()
               : ExpansionTile(
                   controlAffinity: ListTileControlAffinity.leading,
-                  title: Text('Payments Outstanding - ${outstandingCards.length}',
+                  title: Text(
+                      'Payments Outstanding - ${outstandingCards.length}',
                       style:
                           TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                   initiallyExpanded: false,

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -114,57 +114,11 @@ class _ParentHomeState extends State<ParentHome> {
                       c.lastName.toLowerCase().contains(query.toLowerCase()))))
           .map(
         (p) {
-          final parentCard = Card(
-            child: ListTile(
-              title: Text("${p.firstName} ${p.lastName}"),
-              subtitle: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Flexible(
-                    child: Row(
-                      children: [
-                        Icon(Icons.email_rounded, size: 14.0),
-                        SizedBox(width: 4.0),
-                        Expanded(
-                            child: Text(
-                          p.email,
-                          overflow: TextOverflow.ellipsis,
-                          softWrap: false,
-                        )),
-                      ],
-                    ),
-                  ),
-                  Flexible(
-                    child: Row(
-                      children: [
-                        Icon(Icons.phone, size: 14.0),
-                        SizedBox(width: 4.0),
-                        Expanded(
-                            child: Text(
-                          p.phone,
-                          overflow: TextOverflow.ellipsis,
-                          softWrap: false,
-                        )),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              trailing: Icon(Icons.info_outline),
-              onTap: () => {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => ParentDetails(parentId: p.id!),
-                  ),
-                ),
-              },
-            ),
-          );
-
+          final Widget children;
           if ((query.isEmpty && !showScouts) ||
               p.children == null ||
               p.children!.isEmpty) {
-            return parentCard;
+            children = const SizedBox.shrink();
           } else {
             final childrenWidgets = p.children!.map((c) {
               return ElevatedButton.icon(
@@ -172,6 +126,8 @@ class _ParentHomeState extends State<ParentHome> {
                   padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                   minimumSize: Size(0, 0),
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                  foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
                 ),
                 onPressed: () => {
                   Navigator.of(context).push(
@@ -185,22 +141,67 @@ class _ParentHomeState extends State<ParentHome> {
               );
             }).toList();
 
-            return Column(children: [
-              parentCard,
-              Padding(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 32.0, vertical: 8.0),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      alignment: WrapAlignment.start,
-                      children: childrenWidgets,
-                    ),
-                  )),
-            ]);
+            children = Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 32.0, vertical: 8.0),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: Wrap(
+                    spacing: 8.0,
+                    runSpacing: 8.0,
+                    alignment: WrapAlignment.start,
+                    children: childrenWidgets,
+                  ),
+                ));
           }
+          return Card(
+            child: Column(
+              children: [
+                ListTile(
+                  title: Text("${p.firstName} ${p.lastName}"),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(Icons.email_rounded, size: 14.0),
+                          SizedBox(width: 4.0),
+                          Expanded(
+                              child: Text(
+                            p.email,
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: false,
+                          )),
+                        ],
+                      ),
+                      SizedBox(height: 4.0),
+                      Row(
+                        children: [
+                          Icon(Icons.phone, size: 14.0),
+                          SizedBox(width: 4.0),
+                          Expanded(
+                              child: Text(
+                            p.phone,
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: false,
+                          )),
+                        ],
+                      ),
+                    ],
+                  ),
+                  trailing: Icon(Icons.info_outline),
+                  onTap: () => {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => ParentDetails(parentId: p.id!),
+                      ),
+                    ),
+                  },
+                ),
+                children,
+              ],
+            ),
+          );
         },
       ).toList();
 

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -195,7 +195,7 @@ class _ParentHomeState extends State<ParentHome> {
       ).toList();
 
       List<Card> outstandingCards = (outstandingParents
-            ..sort((a, b) => a.$2.compareTo(b.$2)))
+            ..sort((a, b) => b.$2.compareTo(a.$2)))
           .map(
             (e) => Card(
               child: ListTile(

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -13,11 +13,13 @@ class ParentHome extends StatefulWidget {
 }
 
 class _ParentHomeState extends State<ParentHome> {
-  String query = '';
   late List<Parent> allParents;
   late List<(Parent, int)> outstandingParents;
   String? errorMessage;
   bool loading = true;
+
+  String query = '';
+  bool showScouts = true;
 
   final ScrollController _scrollController = ScrollController();
 
@@ -80,15 +82,25 @@ class _ParentHomeState extends State<ParentHome> {
       );
     } else {
       SearchBar searchBar = SearchBar(
-        hintText: 'Search parent, scout, email, phone...',
-        onChanged: (value) => setState(() {
-          query = value;
-        }),
-        leading: Padding(
-          padding: const EdgeInsets.only(left: 8.0),
-          child: const Icon(Icons.search),
-        ),
-      );
+          hintText: 'Search parent, scout, email, phone',
+          onChanged: (value) => setState(() {
+                query = value;
+              }),
+          leading: Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: const Icon(Icons.search),
+          ),
+          trailing: [
+            IconButton(
+              icon: Icon(showScouts ? Icons.person : Icons.person_outline),
+              onPressed: () {
+                setState(() {
+                  showScouts = !showScouts;
+                });
+              },
+              tooltip: showScouts ? 'Hide Scouts' : 'Show Scouts',
+            ),
+          ]);
 
       List<Widget> parentCards = allParents
           .where((e) =>
@@ -149,31 +161,29 @@ class _ParentHomeState extends State<ParentHome> {
             ),
           );
 
-          if (query.isEmpty) {
+          if ((query.isEmpty && !showScouts) ||
+              p.children == null ||
+              p.children!.isEmpty) {
             return parentCard;
           } else {
-            final List<Widget> childrenWidgets = p.children == null
-                ? [const SizedBox.shrink()]
-                : p.children!.map((c) {
-                    return ElevatedButton.icon(
-                      style: ElevatedButton.styleFrom(
-                        padding:
-                            EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-                        minimumSize: Size(0, 0),
-                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      ),
-                      onPressed: () => {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                ScoutDetailsView(scoutId: c.id!),
-                          ),
-                        ),
-                      },
-                      icon: Icon(Icons.person, size: 14.0),
-                      label: Text(c.fullName),
-                    );
-                  }).toList();
+            final childrenWidgets = p.children!.map((c) {
+              return ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                  minimumSize: Size(0, 0),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () => {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => ScoutDetailsView(scoutId: c.id!),
+                    ),
+                  ),
+                },
+                icon: Icon(Icons.person, size: 14.0),
+                label: Text(c.fullName),
+              );
+            }).toList();
 
             return Column(children: [
               parentCard,
@@ -229,10 +239,6 @@ class _ParentHomeState extends State<ParentHome> {
                   children: outstandingCards,
                 ),
           SizedBox(height: 16.0),
-          Text(
-            'All Parents',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-          ),
           SizedBox(height: 8.0),
           searchBar,
           SizedBox(height: 16.0),

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -126,8 +126,10 @@ class _ParentHomeState extends State<ParentHome> {
                   padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
                   minimumSize: Size(0, 0),
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-                  foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
+                  backgroundColor:
+                      Theme.of(context).colorScheme.secondaryContainer,
+                  foregroundColor:
+                      Theme.of(context).colorScheme.onSecondaryContainer,
                 ),
                 onPressed: () => {
                   Navigator.of(context).push(
@@ -142,8 +144,8 @@ class _ParentHomeState extends State<ParentHome> {
             }).toList();
 
             children = Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 32.0, vertical: 8.0),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 32.0, vertical: 8.0),
                 child: SizedBox(
                   width: double.infinity,
                   child: Wrap(

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -89,18 +89,7 @@ class _ParentHomeState extends State<ParentHome> {
           leading: Padding(
             padding: const EdgeInsets.only(left: 8.0),
             child: const Icon(Icons.search),
-          ),
-          trailing: [
-            IconButton(
-              icon: Icon(showScouts ? Icons.person : Icons.person_outline),
-              onPressed: () {
-                setState(() {
-                  showScouts = !showScouts;
-                });
-              },
-              tooltip: showScouts ? 'Hide Scouts' : 'Show Scouts',
-            ),
-          ]);
+          ),);
 
       List<Widget> parentCards = allParents
           .where((e) =>
@@ -227,6 +216,16 @@ class _ParentHomeState extends State<ParentHome> {
             ),
           )
           .toList();
+      
+      final switchWidget = SwitchListTile(
+        title: const Text('Show Scouts'),
+        value: showScouts,
+        onChanged: (value) {
+          setState(() {
+            showScouts = value;
+          });
+        },
+      );
 
       body = ListView(
         controller: _scrollController,
@@ -235,15 +234,15 @@ class _ParentHomeState extends State<ParentHome> {
               ? const SizedBox.shrink()
               : ExpansionTile(
                   controlAffinity: ListTileControlAffinity.leading,
-                  title: const Text('Payments Outstanding',
+                  title: Text('Payments Outstanding - ${outstandingCards.length}',
                       style:
-                          TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                  initiallyExpanded: true,
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  initiallyExpanded: false,
                   children: outstandingCards,
                 ),
           SizedBox(height: 16.0),
-          SizedBox(height: 8.0),
           searchBar,
+          switchWidget,
           SizedBox(height: 16.0),
           ...parentCards,
         ],

--- a/scouts_finances_flutter/lib/payments/home.dart
+++ b/scouts_finances_flutter/lib/payments/home.dart
@@ -120,6 +120,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
           title: Text('Matched Payments - ${matchedPaymentCards.length}'),
           initiallyExpanded: false,
           shape: const Border(),
+          controlAffinity: ListTileControlAffinity.leading,
           children: matchedPaymentCards));
     }
 

--- a/scouts_finances_server/lib/src/admin.dart
+++ b/scouts_finances_server/lib/src/admin.dart
@@ -25,7 +25,11 @@ class UserInfo {
     String? ukPhone;
     if (phone != null) {
       // Strip out brackets, dashes, and plus signs and add country code
-      ukPhone = '+44${phone.replaceAll(RegExp(r'\(|\)|\-|\+'), '')}';
+      String strippedPhone = phone.replaceAll(RegExp(r'\(|\)|\-|\+| '), '');
+      if (strippedPhone.startsWith('0')) {
+        strippedPhone = strippedPhone.substring(1);
+      }
+      ukPhone = '+44$strippedPhone';
     }
 
     return UserInfo(
@@ -221,8 +225,8 @@ class AdminEndpoint extends Endpoint {
         }
 
         // Randomly decide whether to pay in full or partially
-        // 80/20 split
-        final payInFull = Random().nextDouble() < 0.8;
+        // 95/5 split
+        final payInFull = Random().nextDouble() < 0.95;
 
         // Randomly decide the amount to pay if not paying in full
         final int amount = payInFull
@@ -277,10 +281,10 @@ class AdminEndpoint extends Endpoint {
       final insertedPayments =
           await Payment.db.insert(session, payments, transaction: t);
 
-      // Assign ~20% of payments to parents
+      // Assign ~80% of payments to parents
       final assignedPayments = <(Payment payment, Parent parent)>[];
       for (final payment in insertedPayments) {
-        if (Random().nextDouble() < 0.2) {
+        if (Random().nextDouble() < 0.8) {
           // Randomly assign a parent to the payment
           final parent = insertedParents.firstWhere(
             (p) => payment.payee == '${p.firstName} ${p.lastName}',

--- a/scouts_finances_server/lib/src/generated/parent.dart
+++ b/scouts_finances_server/lib/src/generated/parent.dart
@@ -8,8 +8,11 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: unnecessary_null_comparison
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'child.dart' as _i2;
 
 abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
   Parent._({
@@ -19,6 +22,7 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     required this.email,
     required this.phone,
     required this.balance,
+    this.children,
   });
 
   factory Parent({
@@ -28,6 +32,7 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     required String email,
     required String phone,
     required int balance,
+    List<_i2.Child>? children,
   }) = _ParentImpl;
 
   factory Parent.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -38,6 +43,9 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       email: jsonSerialization['email'] as String,
       phone: jsonSerialization['phone'] as String,
       balance: jsonSerialization['balance'] as int,
+      children: (jsonSerialization['children'] as List?)
+          ?.map((e) => _i2.Child.fromJson((e as Map<String, dynamic>)))
+          .toList(),
     );
   }
 
@@ -58,6 +66,8 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
 
   int balance;
 
+  List<_i2.Child>? children;
+
   @override
   _i1.Table<int?> get table => t;
 
@@ -71,6 +81,7 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     String? email,
     String? phone,
     int? balance,
+    List<_i2.Child>? children,
   });
   @override
   Map<String, dynamic> toJson() {
@@ -81,6 +92,8 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       'email': email,
       'phone': phone,
       'balance': balance,
+      if (children != null)
+        'children': children?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -93,11 +106,13 @@ abstract class Parent implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       'email': email,
       'phone': phone,
       'balance': balance,
+      if (children != null)
+        'children': children?.toJson(valueToJson: (v) => v.toJsonForProtocol()),
     };
   }
 
-  static ParentInclude include() {
-    return ParentInclude._();
+  static ParentInclude include({_i2.ChildIncludeList? children}) {
+    return ParentInclude._(children: children);
   }
 
   static ParentIncludeList includeList({
@@ -136,6 +151,7 @@ class _ParentImpl extends Parent {
     required String email,
     required String phone,
     required int balance,
+    List<_i2.Child>? children,
   }) : super._(
           id: id,
           firstName: firstName,
@@ -143,6 +159,7 @@ class _ParentImpl extends Parent {
           email: email,
           phone: phone,
           balance: balance,
+          children: children,
         );
 
   /// Returns a shallow copy of this [Parent]
@@ -156,6 +173,7 @@ class _ParentImpl extends Parent {
     String? email,
     String? phone,
     int? balance,
+    Object? children = _Undefined,
   }) {
     return Parent(
       id: id is int? ? id : this.id,
@@ -164,6 +182,9 @@ class _ParentImpl extends Parent {
       email: email ?? this.email,
       phone: phone ?? this.phone,
       balance: balance ?? this.balance,
+      children: children is List<_i2.Child>?
+          ? children
+          : this.children?.map((e0) => e0.copyWith()).toList(),
     );
   }
 }
@@ -202,6 +223,41 @@ class ParentTable extends _i1.Table<int?> {
 
   late final _i1.ColumnInt balance;
 
+  _i2.ChildTable? ___children;
+
+  _i1.ManyRelation<_i2.ChildTable>? _children;
+
+  _i2.ChildTable get __children {
+    if (___children != null) return ___children!;
+    ___children = _i1.createRelationTable(
+      relationFieldName: '__children',
+      field: Parent.t.id,
+      foreignField: _i2.Child.t.parentId,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.ChildTable(tableRelation: foreignTableRelation),
+    );
+    return ___children!;
+  }
+
+  _i1.ManyRelation<_i2.ChildTable> get children {
+    if (_children != null) return _children!;
+    var relationTable = _i1.createRelationTable(
+      relationFieldName: 'children',
+      field: Parent.t.id,
+      foreignField: _i2.Child.t.parentId,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.ChildTable(tableRelation: foreignTableRelation),
+    );
+    _children = _i1.ManyRelation<_i2.ChildTable>(
+      tableWithRelations: relationTable,
+      table: _i2.ChildTable(
+          tableRelation: relationTable.tableRelation!.lastRelation),
+    );
+    return _children!;
+  }
+
   @override
   List<_i1.Column> get columns => [
         id,
@@ -211,13 +267,25 @@ class ParentTable extends _i1.Table<int?> {
         phone,
         balance,
       ];
+
+  @override
+  _i1.Table? getRelationTable(String relationField) {
+    if (relationField == 'children') {
+      return __children;
+    }
+    return null;
+  }
 }
 
 class ParentInclude extends _i1.IncludeObject {
-  ParentInclude._();
+  ParentInclude._({_i2.ChildIncludeList? children}) {
+    _children = children;
+  }
+
+  _i2.ChildIncludeList? _children;
 
   @override
-  Map<String, _i1.Include?> get includes => {};
+  Map<String, _i1.Include?> get includes => {'children': _children};
 
   @override
   _i1.Table<int?> get table => Parent.t;
@@ -245,6 +313,10 @@ class ParentIncludeList extends _i1.IncludeList {
 
 class ParentRepository {
   const ParentRepository._();
+
+  final attach = const ParentAttachRepository._();
+
+  final attachRow = const ParentAttachRowRepository._();
 
   /// Returns a list of [Parent]s matching the given query parameters.
   ///
@@ -277,6 +349,7 @@ class ParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentTable>? orderByList,
     _i1.Transaction? transaction,
+    ParentInclude? include,
   }) async {
     return session.db.find<Parent>(
       where: where?.call(Parent.t),
@@ -286,6 +359,7 @@ class ParentRepository {
       limit: limit,
       offset: offset,
       transaction: transaction,
+      include: include,
     );
   }
 
@@ -314,6 +388,7 @@ class ParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentTable>? orderByList,
     _i1.Transaction? transaction,
+    ParentInclude? include,
   }) async {
     return session.db.findFirstRow<Parent>(
       where: where?.call(Parent.t),
@@ -322,6 +397,7 @@ class ParentRepository {
       orderDescending: orderDescending,
       offset: offset,
       transaction: transaction,
+      include: include,
     );
   }
 
@@ -330,10 +406,12 @@ class ParentRepository {
     _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
+    ParentInclude? include,
   }) async {
     return session.db.findById<Parent>(
       id,
       transaction: transaction,
+      include: include,
     );
   }
 
@@ -451,6 +529,60 @@ class ParentRepository {
     return session.db.count<Parent>(
       where: where?.call(Parent.t),
       limit: limit,
+      transaction: transaction,
+    );
+  }
+}
+
+class ParentAttachRepository {
+  const ParentAttachRepository._();
+
+  /// Creates a relation between this [Parent] and the given [Child]s
+  /// by setting each [Child]'s foreign key `parentId` to refer to this [Parent].
+  Future<void> children(
+    _i1.Session session,
+    Parent parent,
+    List<_i2.Child> child, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (child.any((e) => e.id == null)) {
+      throw ArgumentError.notNull('child.id');
+    }
+    if (parent.id == null) {
+      throw ArgumentError.notNull('parent.id');
+    }
+
+    var $child = child.map((e) => e.copyWith(parentId: parent.id)).toList();
+    await session.db.update<_i2.Child>(
+      $child,
+      columns: [_i2.Child.t.parentId],
+      transaction: transaction,
+    );
+  }
+}
+
+class ParentAttachRowRepository {
+  const ParentAttachRowRepository._();
+
+  /// Creates a relation between this [Parent] and the given [Child]
+  /// by setting the [Child]'s foreign key `parentId` to refer to this [Parent].
+  Future<void> children(
+    _i1.Session session,
+    Parent parent,
+    _i2.Child child, {
+    _i1.Transaction? transaction,
+  }) async {
+    if (child.id == null) {
+      throw ArgumentError.notNull('child.id');
+    }
+    if (parent.id == null) {
+      throw ArgumentError.notNull('parent.id');
+    }
+
+    var $child = child.copyWith(parentId: parent.id);
+    await session.db.updateRow<_i2.Child>(
+      $child,
+      columns: [_i2.Child.t.parentId],
       transaction: transaction,
     );
   }

--- a/scouts_finances_server/lib/src/generated/protocol.dart
+++ b/scouts_finances_server/lib/src/generated/protocol.dart
@@ -605,6 +605,11 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<_i4.Child>(e)).toList()
           : null) as T;
     }
+    if (t == _i1.getType<List<_i4.Child>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i4.Child>(e)).toList()
+          : null) as T;
+    }
     if (t == _i1.getType<List<_i6.Event>?>()) {
       return (data != null
           ? (data as List).map((e) => deserialize<_i6.Event>(e)).toList()

--- a/scouts_finances_server/lib/src/models/child.spy.yaml
+++ b/scouts_finances_server/lib/src/models/child.spy.yaml
@@ -3,5 +3,5 @@ table: children
 fields:
   firstName: String
   lastName: String
-  parent: Parent?, relation
+  parent: Parent?, relation(name=parent_children)
   scoutGroup: ScoutGroup?, relation(name=scout_group_children)

--- a/scouts_finances_server/lib/src/models/parent.spy.yaml
+++ b/scouts_finances_server/lib/src/models/parent.spy.yaml
@@ -6,3 +6,4 @@ fields:
     email: String
     phone: String
     balance: int
+    children: List<Child>?, relation(name=parent_children)

--- a/scouts_finances_server/lib/src/parent.dart
+++ b/scouts_finances_server/lib/src/parent.dart
@@ -5,11 +5,13 @@ import 'package:serverpod/serverpod.dart';
 
 class ParentEndpoint extends Endpoint {
   Future<List<Parent>> getParents(Session session) async {
-    return Parent.db.find(session);
+    return Parent.db
+        .find(session, include: Parent.include(children: Child.includeList()));
   }
 
   Future<Parent?> getParentById(Session session, int id) async {
-    return Parent.db.findById(session, id);
+    return Parent.db.findById(session, id,
+        include: Parent.include(children: Child.includeList()));
   }
 
   Future<void> addBalance(Session session, int parentId, int amount) async {


### PR DESCRIPTION
misc: 
- matched payment dropdown tooltip thing is now on the left; consistency
- child-parent relation is two way in serverpod so you can get children from parent 
- number conforms better to uk +44xxx with no gaps and not starting in 0
- most outstanding parent first
big feet:
- parents & scout tab replaced by people tab, can search by either
- show scouts toggle button in people tab 