### PR TITLE
Fix/various

### DIFF
--- a/scouts_finances_flutter/lib/events/home.dart
+++ b/scouts_finances_flutter/lib/events/home.dart
@@ -123,7 +123,7 @@ class _EventHomeState extends State<EventHome> {
                 const Spacer(),
                 Icon(Icons.calendar_today, size: 14),
                 const SizedBox(width: 4.0),
-                Text(event.date.toLocal().toIso8601String().split('T')[0]),
+                Text(event.date.toLocal().toString().split(' ')[0]),
               ],
             ),
             onTap: () {

--- a/scouts_finances_flutter/lib/events/home.dart
+++ b/scouts_finances_flutter/lib/events/home.dart
@@ -23,8 +23,8 @@ class _EventHomeState extends State<EventHome> {
   final sorts = [
     'Upcoming First',
     'Upcoming Last',
-    'Paid count',
-    'Unpaid count',
+    'Most Paid',
+    'Fewest Paid',
   ];
   int sortIndex = 0;
   String query = '';
@@ -53,7 +53,7 @@ class _EventHomeState extends State<EventHome> {
     } catch (e) {
       setState(() {
         errorMessage =
-            'Failed to load paid counts. Are you connected to the internet?';
+            'Failed to load event details (pay counts). Are you connected to the internet?';
       });
     }
     loading--;

--- a/scouts_finances_flutter/lib/events/home.dart
+++ b/scouts_finances_flutter/lib/events/home.dart
@@ -220,6 +220,16 @@ class _EventHomeState extends State<EventHome> {
             return const AddEventDialog();
           },
         ).then((_) {
+          if (!mounted) return;
+          // Use addPostFrameCallback to ensure context is valid after async gap
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                backgroundColor: Colors.green,
+                content: Text('Event added successfully'),
+              ),
+            );
+          });
           // Refresh the event list after adding a new event
           _getEvents();
         });

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:scouts_finances_client/scouts_finances_client.dart';
 import 'package:scouts_finances_flutter/events/event_add_participant.dart';
 import 'package:scouts_finances_flutter/main.dart';
+import 'package:scouts_finances_flutter/scouts/scout_details.dart';
 
 typedef EventDetails = (Event, List<EventRegistration>);
 
@@ -124,7 +125,22 @@ class _SingleEventState extends State<SingleEvent> {
           .map((e) => DataRow(
                   cells: [
                     DataCell(Row(children: [
-                      Text(e.name),
+                      TextButton(
+                          style: TextButton.styleFrom(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 0),
+                            minimumSize: Size(0, 0),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          ),
+                          child: Text(e.name),
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (context) =>
+                                    ScoutDetailsView(scoutId: e.childId!),
+                              ),
+                            );
+                          }),
                     ])),
                     DataCell(Text(e.paidDate == null
                         ? 'Not paid'

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -125,15 +125,6 @@ class _SingleEventState extends State<SingleEvent> {
                   cells: [
                     DataCell(Row(children: [
                       Text(e.name),
-                      // ElevatedButton(
-                      //   onPressed: () {
-                      //     // Handle button press, e.g., navigate to child's profile
-                      //   },
-                      //   style: ElevatedButton.styleFrom(
-                      //     shape: const CircleBorder(),
-                      //   ),
-                      //   child: const Icon(Icons.arrow_forward, size: 16),
-                      // )
                     ])),
                     DataCell(Text(e.paidDate == null
                         ? 'Not paid'
@@ -144,21 +135,12 @@ class _SingleEventState extends State<SingleEvent> {
                       : WidgetStateProperty.all(
                           const Color.fromARGB(199, 1, 230, 104))))
           .toList(),
-      // decoration: BoxDecoration(
-      //   border: Border.all(color: colourScheme.secondary, width: 2),
-      //   borderRadius: BorderRadius.circular(10),
-      //   color: colourScheme.secondaryContainer,
-      // ),
       border: TableBorder.symmetric(
           inside: BorderSide(
             color: colourScheme.onSecondaryContainer,
             width: 0.5,
           ),
           outside: BorderSide.none),
-      // border: TableBorder.all(
-      //   color: colourScheme.onSecondaryContainer,
-      //   width: 0.5,
-      // ),
     );
 
     SearchBar searchBar = SearchBar(
@@ -258,18 +240,6 @@ class _SingleEventState extends State<SingleEvent> {
                         clipBehavior: Clip.antiAlias,
                         child: childrenTable,
                       ),
-                      // Row(
-                      //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      //   children: [
-                      //     SizedBox(
-                      //       width: 200, // Fixed width
-                      //       child: EventAddParticipant(
-                      //         eventId: widget.eventId,
-                      //         closeFn: () => _getEventDetails(),
-                      //       ),
-                      //     ),
-                      //   ],
-                      // ),
                       EventAddParticipant(
                         eventId: widget.eventId,
                         closeFn: () => _getEventDetails(),

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -23,8 +23,8 @@ class _SingleEventState extends State<SingleEvent> {
   final sorts = [
     'First Name',
     'Last Name',
-    'Paid First',
-    'Paid Last',
+    'Paid',
+    'Unpaid',
   ];
   int sortIndex = 0;
 
@@ -245,6 +245,7 @@ class _SingleEventState extends State<SingleEvent> {
                         closeFn: () => _getEventDetails(),
                       ),
                     ])),
+                const SizedBox(height: 128.0),
               ],
             ),
           ),

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -204,77 +204,79 @@ class _SingleEventState extends State<SingleEvent> {
         appBar: AppBar(
           title: Text(event.name),
         ),
-        body: Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Table(columnWidths: {
-                0: IntrinsicColumnWidth(),
-              }, children: [
-                TableRow(children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: Text(
-                      'Date:',
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  Text(
-                      "${event.date.day}/${event.date.month}/${event.date.year}"),
-                ]),
-                TableRow(children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: Text('Location:',
-                        style: TextStyle(fontWeight: FontWeight.bold)),
-                  ),
-                  Text('TBD'),
-                ]),
-                TableRow(children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                    child: Text('Price:',
-                        style: TextStyle(fontWeight: FontWeight.bold)),
-                  ),
-                  Text('£${(event.cost / 100).toStringAsFixed(2)}'),
-                ]),
-              ]),
-              Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Column(children: [
-                    const SizedBox(height: 16),
-                    searchBar,
-                    sortSelection,
-                    const SizedBox(height: 16),
-                    Card(
-                      shape: RoundedRectangleBorder(
-                        borderRadius:
-                            BorderRadius.circular(10), // Sets rounded corners
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Table(columnWidths: {
+                  0: IntrinsicColumnWidth(),
+                }, children: [
+                  TableRow(children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: Text(
+                        'Date:',
+                        style: TextStyle(fontWeight: FontWeight.bold),
                       ),
-                      color: colourScheme.secondaryContainer,
-                      clipBehavior: Clip.antiAlias,
-                      child: childrenTable,
                     ),
-                    // Row(
-                    //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    //   children: [
-                    //     SizedBox(
-                    //       width: 200, // Fixed width
-                    //       child: EventAddParticipant(
-                    //         eventId: widget.eventId,
-                    //         closeFn: () => _getEventDetails(),
-                    //       ),
-                    //     ),
-                    //   ],
-                    // ),
-                    EventAddParticipant(
-                      eventId: widget.eventId,
-                      closeFn: () => _getEventDetails(),
+                    Text(
+                        "${event.date.day}/${event.date.month}/${event.date.year}"),
+                  ]),
+                  TableRow(children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: Text('Location:',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
                     ),
-                  ])),
-            ],
+                    Text('TBD'),
+                  ]),
+                  TableRow(children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: Text('Price:',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                    Text('£${(event.cost / 100).toStringAsFixed(2)}'),
+                  ]),
+                ]),
+                Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Column(children: [
+                      const SizedBox(height: 16),
+                      searchBar,
+                      sortSelection,
+                      const SizedBox(height: 16),
+                      Card(
+                        shape: RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.circular(10), // Sets rounded corners
+                        ),
+                        color: colourScheme.secondaryContainer,
+                        clipBehavior: Clip.antiAlias,
+                        child: childrenTable,
+                      ),
+                      // Row(
+                      //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      //   children: [
+                      //     SizedBox(
+                      //       width: 200, // Fixed width
+                      //       child: EventAddParticipant(
+                      //         eventId: widget.eventId,
+                      //         closeFn: () => _getEventDetails(),
+                      //       ),
+                      //     ),
+                      //   ],
+                      // ),
+                      EventAddParticipant(
+                        eventId: widget.eventId,
+                        closeFn: () => _getEventDetails(),
+                      ),
+                    ])),
+              ],
+            ),
           ),
         ));
   }

--- a/scouts_finances_flutter/lib/parents/all_parents.dart
+++ b/scouts_finances_flutter/lib/parents/all_parents.dart
@@ -67,10 +67,10 @@ class AllParentsViewState extends State<AllParentsView> {
     }
   }
 
-  void _scrollToBottom() {
+  void _scrollToTop() {
     if (_scrollController.hasClients) {
       _scrollController.animateTo(
-        _scrollController.position.maxScrollExtent,
+        _scrollController.position.minScrollExtent,
         duration: const Duration(milliseconds: 300),
         curve: Curves.easeOut,
       );
@@ -79,7 +79,7 @@ class AllParentsViewState extends State<AllParentsView> {
 
   void refresh() {
     _getParents();
-    _scrollToBottom();
+    _scrollToTop();
   }
 
   @override

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -41,6 +41,11 @@ class ParentHome extends StatelessWidget {
             context: context,
             onParentAdded: () {
               _allParentsKey.currentState?.refresh();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  backgroundColor: Colors.green,
+                  content: Text('Parent added successfully')),
+              );
             },
           )),
     );

--- a/scouts_finances_flutter/lib/parents/home.dart
+++ b/scouts_finances_flutter/lib/parents/home.dart
@@ -43,8 +43,8 @@ class ParentHome extends StatelessWidget {
               _allParentsKey.currentState?.refresh();
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(
-                  backgroundColor: Colors.green,
-                  content: Text('Parent added successfully')),
+                    backgroundColor: Colors.green,
+                    content: Text('Parent added successfully')),
               );
             },
           )),

--- a/scouts_finances_flutter/lib/parents/parent_details.dart
+++ b/scouts_finances_flutter/lib/parents/parent_details.dart
@@ -148,7 +148,7 @@ class _ParentDetailsState extends State<ParentDetails> {
             ],
           ),
           const SizedBox(height: 16),
-          const Text('Payment History:',
+          const Text('Transaction History:',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           ParentTransactionTable(

--- a/scouts_finances_flutter/lib/payments/add.dart
+++ b/scouts_finances_flutter/lib/payments/add.dart
@@ -5,7 +5,8 @@ import 'package:scouts_finances_flutter/main.dart';
 import 'package:flutter_masked_text3/flutter_masked_text3.dart';
 
 class AddPaymentDialog extends StatefulWidget {
-  const AddPaymentDialog({super.key});
+  const AddPaymentDialog({super.key, required this.onSubmit});
+  final Function onSubmit;
 
   @override
   State<AddPaymentDialog> createState() => _AddPaymentDialogState();
@@ -43,7 +44,7 @@ class _AddPaymentDialogState extends State<AddPaymentDialog> {
     }
   }
 
-  void _submit() {
+  void _submit() async {
     if (_formKey.currentState?.validate() ?? false) {
       final newPayment = Payment(
         amount: (_amountController.numberValue! * 100).truncate(),
@@ -52,13 +53,15 @@ class _AddPaymentDialogState extends State<AddPaymentDialog> {
         date: _selectedDate ?? DateTime.now(),
         reference: _referenceController.text,
       );
-      client.payment.insertPayment(newPayment);
+      await client.payment.insertPayment(newPayment);
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           backgroundColor: Colors.green,
           content: Text('Payment added successfully'),
         ),
       );
+      widget.onSubmit();
       Navigator.of(context).pop();
     }
   }

--- a/scouts_finances_flutter/lib/payments/add.dart
+++ b/scouts_finances_flutter/lib/payments/add.dart
@@ -53,6 +53,12 @@ class _AddPaymentDialogState extends State<AddPaymentDialog> {
         reference: _referenceController.text,
       );
       client.payment.insertPayment(newPayment);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          backgroundColor: Colors.green,
+          content: Text('Payment added successfully'),
+        ),
+      );
       Navigator.of(context).pop();
     }
   }

--- a/scouts_finances_flutter/lib/payments/home.dart
+++ b/scouts_finances_flutter/lib/payments/home.dart
@@ -11,6 +11,9 @@ class PaymentsHome extends StatefulWidget {
 }
 
 class _PaymentsHomeState extends State<PaymentsHome> {
+  final GlobalKey<UnmatchedViewState> unmatchedViewKey =
+      GlobalKey<UnmatchedViewState>();
+
   String query = '';
   final TextEditingController _searchController = TextEditingController();
 
@@ -55,7 +58,7 @@ class _PaymentsHomeState extends State<PaymentsHome> {
               child: Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: TabBarView(children: [
-                    UnmatchedView(searchBar: searchBar, query: query),
+                    UnmatchedView(searchBar: searchBar, query: query, key: unmatchedViewKey),
                     MatchedView(searchBar: searchBar, query: query),
                   ])),
             )
@@ -67,7 +70,9 @@ class _PaymentsHomeState extends State<PaymentsHome> {
             showDialog(
               context: context,
               builder: (BuildContext context) {
-                return AddPaymentDialog();
+                return AddPaymentDialog(onSubmit: () {
+                  unmatchedViewKey.currentState?.refresh();
+                });
               },
             );
           },

--- a/scouts_finances_flutter/lib/payments/home.dart
+++ b/scouts_finances_flutter/lib/payments/home.dart
@@ -58,7 +58,10 @@ class _PaymentsHomeState extends State<PaymentsHome> {
               child: Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: TabBarView(children: [
-                    UnmatchedView(searchBar: searchBar, query: query, key: unmatchedViewKey),
+                    UnmatchedView(
+                        searchBar: searchBar,
+                        query: query,
+                        key: unmatchedViewKey),
                     MatchedView(searchBar: searchBar, query: query),
                   ])),
             )

--- a/scouts_finances_flutter/lib/payments/payment_table.dart
+++ b/scouts_finances_flutter/lib/payments/payment_table.dart
@@ -35,7 +35,7 @@ class PaymentTable extends StatelessWidget {
         TableRow(children: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            child: Text("Payee", style: TextStyle(fontWeight: FontWeight.bold)),
+            child: Text("Payee Name", style: TextStyle(fontWeight: FontWeight.bold)),
           ),
           Text(payment.payee),
         ]),

--- a/scouts_finances_flutter/lib/payments/payment_table.dart
+++ b/scouts_finances_flutter/lib/payments/payment_table.dart
@@ -35,7 +35,8 @@ class PaymentTable extends StatelessWidget {
         TableRow(children: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            child: Text("Payee Name", style: TextStyle(fontWeight: FontWeight.bold)),
+            child: Text("Payee Name",
+                style: TextStyle(fontWeight: FontWeight.bold)),
           ),
           Text(payment.payee),
         ]),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -98,22 +98,20 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
               "No parents found. This suggests there is an internal error. Please contact the developers."));
     } else {
       Widget parentSelection = Wrap(
-        alignment: WrapAlignment.start,
-        crossAxisAlignment: WrapCrossAlignment.center,
-
-        children: [
-        Text("Attribute to parent: ",
-            style: TextStyle(fontSize: 16)),
-        ParentDropdown(
-          parents: parents,
-          defaultParentId: parents[parentIndex].id,
-          onChanged: (p) {
-            setState(() {
-              parentIndex = parents.indexWhere((parent) => parent.id == p);
-            });
-          },
-        )
-      ]);
+          alignment: WrapAlignment.start,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text("Attribute to parent: ", style: TextStyle(fontSize: 16)),
+            ParentDropdown(
+              parents: parents,
+              defaultParentId: parents[parentIndex].id,
+              onChanged: (p) {
+                setState(() {
+                  parentIndex = parents.indexWhere((parent) => parent.id == p);
+                });
+              },
+            )
+          ]);
 
       List<EventRegistration> unpaidEventsForParent = unpaidEvents
           .where((eventReg) => eventReg.child!.parentId == currParent.id)

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -97,8 +97,12 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           child: Text(
               "No parents found. This suggests there is an internal error. Please contact the developers."));
     } else {
-      Row parentSelection = Row(children: [
-        Text("Attribute this payment to a parent: ",
+      Widget parentSelection = Wrap(
+        alignment: WrapAlignment.start,
+        crossAxisAlignment: WrapCrossAlignment.center,
+
+        children: [
+        Text("Attribute to parent: ",
             style: TextStyle(fontSize: 16)),
         ParentDropdown(
           parents: parents,

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -164,9 +164,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                           (event) => DataRow(
                             cells: [
                               DataCell(Text(
-                                event.event!.date
-                                    .toString()
-                                    .split(' ')[0],
+                                event.event!.date.toString().split(' ')[0],
                               )),
                               DataCell(Text(
                                   '${event.child!.firstName} ${event.child!.lastName}')),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -165,8 +165,8 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
                             cells: [
                               DataCell(Text(
                                 event.event!.date
-                                    .toIso8601String()
-                                    .split('T')[0],
+                                    .toString()
+                                    .split(' ')[0],
                               )),
                               DataCell(Text(
                                   '${event.child!.firstName} ${event.child!.lastName}')),

--- a/scouts_finances_flutter/lib/payments/single_payment.dart
+++ b/scouts_finances_flutter/lib/payments/single_payment.dart
@@ -248,7 +248,20 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
           ...clearedEventsInfo,
           const SizedBox(height: 16),
           ElevatedButton(
-            onPressed: submit,
+            onPressed: () async {
+              _submit();
+              if (context.mounted) {
+                // ignore: use_build_context_synchronously
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    showCloseIcon: true,
+                    content: Text(
+                        'Payment attributed to ${currParent.fullName} successfully.'),
+                    backgroundColor: Colors.green,
+                  ),
+                );
+              }
+            },
             child: Row(
               children: [
                 Text('Attribute payment to ${currParent.fullName}'),
@@ -272,7 +285,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
     );
   }
 
-  void submit() async {
+  void _submit() async {
     if (payment == null || parents.isEmpty) return;
 
     try {
@@ -282,6 +295,7 @@ class _SinglePaymentViewState extends State<SinglePaymentView> {
         // ignore: use_build_context_synchronously
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
+            showCloseIcon: true,
             content: Text('Failed to classify payment: $e'),
             backgroundColor: Colors.red,
           ),

--- a/scouts_finances_flutter/lib/payments/unmatched_view.dart
+++ b/scouts_finances_flutter/lib/payments/unmatched_view.dart
@@ -52,6 +52,14 @@ class UnmatchedViewState extends State<UnmatchedView> {
     _getPayments();
   }
 
+  void refresh() {
+    setState(() {
+      loading = true;
+      err = null;
+    });
+    _getPayments();
+  }
+
   @override
   Widget build(BuildContext context) {
     // Get which payments are action required

--- a/scouts_finances_flutter/lib/scouts/events_table.dart
+++ b/scouts_finances_flutter/lib/scouts/events_table.dart
@@ -97,8 +97,8 @@ class _ChildEventsTableState extends State<ChildEventsTable> {
                             cells: [
                               DataCell(Text(r.event!.date
                                   .toLocal()
-                                  .toIso8601String()
-                                  .split('T')[0])),
+                                  .toString()
+                                  .split(' ')[0])),
                               DataCell(Text(r.event!.name)),
                               DataCell(Text(
                                   (r.event!.cost / 100).toStringAsFixed(2))),

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -128,8 +128,8 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
                           cells: [
                             DataCell(Text(tx.date
                                 .toLocal()
-                                .toIso8601String()
-                                .split('T')[0])),
+                                .toString()
+                                .split(' ')[0])),
                             DataCell(Text(tx.description)),
                             DataCell(Text(tx.amount.toStringAsFixed(2))),
                           ],

--- a/scouts_finances_flutter/lib/shared/parent_transactions.dart
+++ b/scouts_finances_flutter/lib/shared/parent_transactions.dart
@@ -126,10 +126,8 @@ class _ParentTransactionTableState extends State<ParentTransactionTable> {
                       .map(
                         (tx) => DataRow(
                           cells: [
-                            DataCell(Text(tx.date
-                                .toLocal()
-                                .toString()
-                                .split(' ')[0])),
+                            DataCell(Text(
+                                tx.date.toLocal().toString().split(' ')[0])),
                             DataCell(Text(tx.description)),
                             DataCell(Text(tx.amount.toStringAsFixed(2))),
                           ],

--- a/scouts_finances_flutter/lib/shared/unpaid_events.dart
+++ b/scouts_finances_flutter/lib/shared/unpaid_events.dart
@@ -99,8 +99,8 @@ class _UnpaidEventsTableState extends State<UnpaidEventsTable> {
                           cells: [
                             DataCell(Text(r.event!.date
                                 .toLocal()
-                                .toIso8601String()
-                                .split('T')[0])),
+                                .toString()
+                                .split(' ')[0])),
                             DataCell(Text(r.event!.name)),
                             DataCell(Text(r.child!.firstName)),
                             DataCell(

--- a/scouts_finances_server/lib/src/parent.dart
+++ b/scouts_finances_server/lib/src/parent.dart
@@ -57,7 +57,7 @@ class ParentEndpoint extends Endpoint {
       buffer.writeln(reminder);
     }
 
-    buffer.writeln('Thank you for your attention!');
+    buffer.writeln('Thank you for your attention!\n NB: This is an automated message, please do not reply.');
 
     final message = buffer.toString();
 

--- a/scouts_finances_server/lib/src/parent.dart
+++ b/scouts_finances_server/lib/src/parent.dart
@@ -57,7 +57,8 @@ class ParentEndpoint extends Endpoint {
       buffer.writeln(reminder);
     }
 
-    buffer.writeln('Thank you for your attention!\n NB: This is an automated message, please do not reply.');
+    buffer.writeln(
+        'Thank you for your attention!\n NB: This is an automated message, please do not reply.');
 
     final message = buffer.toString();
 


### PR DESCRIPTION
Various fixes including but not limited to:
alison in-person
individual event
'select scouts' too vague -> 'add scouts'
not obvious when you can't add more scouts
clicking through to scout for personal and parental details would be very useful
parent list 
transaction history "Event: " not necessary
dates are the wrong way round "japanese format"
confusion about positive and negative values in transaction history
confusion around payments, balance and total due. why is balance positive when they owe we should replace balance with the number we put as total due I think.
payments
unclassified is weird -> 'unattributed'
'payee' -> 'payee name'
scouts tab is more confusing than useful, is interested in search parents by scout
we need to get the multiple children stuff sorted
dummy data is bad and confusing
j — 05:15
more sya feedback
export buttons need to actually work
rename theme colour to group colour
phrasing of "paid count" is a lil awkward in sorting events
events tab overflows, fix
paid first/paid last awkawrd wording in sorting  event details
done button/n selected scouts button in select scout menu is awkward; overhaul that
add some notion of feedback after you do things like classify event, add scouts, etc etc
delete view payments button / any redundent buttons in settings
fix payment match overflow
add smth like "auto msg don't reply" to SMS
zoom/scaling option on app, or just highlight it works w phone accessibility
“is the amount in single scout detail need to pay, paid, monthly sub?”
payment outstanding being at top is awkward
closing payments outstanding then scrolling down and up reopens it and sya is going insane
input validation on parent/scout/etc creation