### PR TITLE
feat: leaders view

### DIFF
--- a/scouts_finances_flutter/lib/events/home.dart
+++ b/scouts_finances_flutter/lib/events/home.dart
@@ -107,17 +107,25 @@ class _EventHomeState extends State<EventHome> {
     });
 
     Widget eventExpansionTile =
-        Consumer<ScoutGroupsService>(builder: (context, value, child) {
+        Consumer2<ScoutGroupsService, AccountTypeService>(
+            builder: (context, scoutGroupService, accountTypeService, child) {
+      final accountType = accountTypeService.accountType;
+
       final relevantEvents = filteredEvents
-          .where((e) => e.scoutGroupId == value.currentScoutGroup.id)
+          .where((e) =>
+              (e.scoutGroupId == scoutGroupService.currentScoutGroup.id) ||
+              accountType == AccountType.treasurer)
           .toList();
 
       List<Card> eventCards = relevantEvents.map((event) {
         final (paid, total) = paidCounts[event.id!] ?? (0, 0);
+        String trailing = accountType == AccountType.treasurer
+            ? '- ${event.scoutGroup!.name}'
+            : '';
 
         return Card(
           child: ListTile(
-            title: Text(event.name),
+            title: Text('${event.name} $trailing'),
             subtitle: Row(
               children: [
                 Text('$paid/$total Paid'),

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:scouts_finances_client/scouts_finances_client.dart';
 import 'package:scouts_finances_flutter/events/event_add_participant.dart';
 import 'package:scouts_finances_flutter/extensions/name.dart';
 import 'package:scouts_finances_flutter/main.dart';
 import 'package:scouts_finances_flutter/payments/add.dart';
 import 'package:scouts_finances_flutter/scouts/scout_details.dart';
+import 'package:scouts_finances_flutter/services/account_type_service.dart';
 
 typedef EventDetails = (Event, List<EventRegistration>);
 
@@ -208,7 +210,10 @@ class _SingleEventState extends State<SingleEvent> {
 
     return Scaffold(
         appBar: AppBar(
-          title: Text(event.name),
+          title:
+              Provider.of<AccountTypeService>(context, listen: false).isLeader
+                  ? Text(event.name)
+                  : Text("${event.name} - ${event.scoutGroup!.name}"),
         ),
         body: SingleChildScrollView(
           child: Padding(
@@ -224,6 +229,17 @@ class _SingleEventState extends State<SingleEvent> {
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8.0),
                       child: Text(
+                        'Details',
+                        style: TextStyle(
+                            fontSize: 24, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    const SizedBox.shrink(),
+                  ]),
+                  TableRow(children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: Text(
                         'Date:',
                         style: TextStyle(fontWeight: FontWeight.bold),
                       ),
@@ -231,14 +247,14 @@ class _SingleEventState extends State<SingleEvent> {
                     Text(
                         "${event.date.day}/${event.date.month}/${event.date.year}"),
                   ]),
-                  TableRow(children: [
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: Text('Location:',
-                          style: TextStyle(fontWeight: FontWeight.bold)),
-                    ),
-                    Text('TBD'),
-                  ]),
+                  // TableRow(children: [
+                  //   Padding(
+                  //     padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  //     child: Text('Location:',
+                  //         style: TextStyle(fontWeight: FontWeight.bold)),
+                  //   ),
+                  //   Text('TBD'),
+                  // ]),
                   TableRow(children: [
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8.0),

--- a/scouts_finances_flutter/lib/main.dart
+++ b/scouts_finances_flutter/lib/main.dart
@@ -185,10 +185,8 @@ class _HomePageState extends State<HomePage> {
         ),
         centerTitle: false,
         actions: [
-          if (accountType == AccountType.leader)
-            selectScoutGroup
-          else
-            OptionsMenu(selectedIndex: currentPageIndex)
+          if (accountType == AccountType.leader) selectScoutGroup,
+          OptionsMenu(selectedIndex: currentPageIndex)
         ],
       ),
       bottomNavigationBar: NavigationBar(

--- a/scouts_finances_flutter/lib/popups.dart
+++ b/scouts_finances_flutter/lib/popups.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:scouts_finances_flutter/extensions/datetime.dart';
+import 'package:scouts_finances_flutter/services/account_type_service.dart';
 import 'package:scouts_finances_flutter/settings/home.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -11,18 +13,19 @@ class OptionsMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (selectedIndex) {
-      case 0:
-        return EventOptionsMenu();
-      case 1:
-        return PaymentsOptionsMenu();
-      // case 2:
-      //   return ScoutsOptionsMenu();
-      case 2:
-        return PeopleOptionsMenu();
-      default:
+    return Consumer<AccountTypeService>(
+      builder: (context, accountTypeService, child) {
+        final accountType = accountTypeService.accountType;
+        final menuOptions = accountType == AccountType.leader
+            ? [EventOptionsMenu(), PaymentsOptionsMenu(), PeopleOptionsMenu()]
+            : [EventOptionsMenu(), PeopleOptionsMenu()];
+
+        if (selectedIndex >= 0 && selectedIndex < menuOptions.length) {
+          return menuOptions[selectedIndex];
+        }
         return const SizedBox.shrink();
-    }
+      },
+    );
   }
 }
 

--- a/scouts_finances_flutter/lib/services/account_type_service.dart
+++ b/scouts_finances_flutter/lib/services/account_type_service.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+enum AccountType {
+  treasurer(name: 'Treasurer'),
+  leader(name: 'Leader');
+
+  final String name;
+  const AccountType({required this.name});
+}
+
+class AccountTypeService extends ChangeNotifier {
+  AccountType _accountType = AccountType.treasurer;
+
+  AccountType get accountType => _accountType;
+
+  void setAccountType(AccountType type) {
+    _accountType = type;
+    notifyListeners();
+  }
+
+  String get accountTypeName => _accountType.name;
+
+  bool get isTreasurer => _accountType == AccountType.treasurer;
+
+  bool get isLeader => _accountType == AccountType.leader;
+}

--- a/scouts_finances_server/lib/src/events.dart
+++ b/scouts_finances_server/lib/src/events.dart
@@ -6,7 +6,8 @@ typedef EventPaidCounts = Map<int, (int paidCount, int totalCount)>;
 
 class EventEndpoint extends Endpoint {
   Future<List<Event>> getEvents(Session session) async {
-    return Event.db.find(session);
+    return Event.db.find(session,
+        include: Event.include(scoutGroup: ScoutGroup.include()));
   }
 
   Future<Map<int, (int, int)>> getPaidCounts(Session session) async {
@@ -28,7 +29,8 @@ class EventEndpoint extends Endpoint {
   }
 
   Future<EventDetails> getEventById(Session session, int id) async {
-    final eventDetails = await Event.db.findById(session, id);
+    final eventDetails = await Event.db.findById(session, id,
+        include: Event.include(scoutGroup: ScoutGroup.include()));
 
     if (eventDetails == null) {
       throw ArgumentError('Event with id $id not found');


### PR DESCRIPTION
- introduced enum of accounttype + relevant service, either treasurer or leader
- leader doesn't see income, can filter by groups
- treasurer can't filter by groups, does see income. also has `- group` after event names. also doesn't have add event button