### PR TITLE
fix: manage scouts properly .then()s so allChildren isnt used before init

### DIFF
--- a/scouts_finances_flutter/lib/events/event_add_participant.dart
+++ b/scouts_finances_flutter/lib/events/event_add_participant.dart
@@ -31,7 +31,7 @@ class _EventAddParticipantState extends State<EventAddParticipant> {
 
   late StreamSubscription stream;
 
-  void _getChildren() async {
+  Future<void> _getChildren() async {
     try {
       allChildren = await client.scouts.getChildren();
     } catch (e) {
@@ -56,20 +56,22 @@ class _EventAddParticipantState extends State<EventAddParticipant> {
     loading--;
   }
 
-  void refresh() {
+  void refresh() async {
     setState(() {
       loading = 2;
       err = null;
     });
-    _getChildren();
-    _getEventChildren();
+    _getChildren().then((_) {
+      _getEventChildren();
+    });
   }
 
   @override
   void initState() {
     super.initState();
-    _getChildren();
-    _getEventChildren();
+    _getChildren().then((_) {
+      _getEventChildren();
+    });
     stream = client.event.eventStream().listen((_) {
       refresh();
     });

--- a/scouts_finances_flutter/lib/events/single_event.dart
+++ b/scouts_finances_flutter/lib/events/single_event.dart
@@ -345,7 +345,8 @@ class _SingleEventState extends State<SingleEvent> {
                     closeFn: () => _getEventDetails(),
                   ),
                 ])),
-            if (children.isNotEmpty) reminderButton
+            if (children.isNotEmpty) reminderButton,
+            const SizedBox(height: 128),
           ],
         ),
       ),

--- a/scouts_finances_server/lib/src/payments.dart
+++ b/scouts_finances_server/lib/src/payments.dart
@@ -135,7 +135,7 @@ class PaymentEndpoint extends Endpoint {
     buffer.writeln('Dear ${parent.firstName},\n');
 
     buffer.writeln(
-        'Your payment of ${assignablePayments.fold(0, (sum, p) => sum + p.amount).formatMoney} have been recieved and processed successfully.');
+        'Your payment of ${assignablePayments.fold(0, (sum, p) => sum + p.amount).formatMoney} has been recieved and processed successfully.');
     buffer.writeln('Your new financial standing is as follows:');
     final financialStanding = await eventRemindersForParent(session, parent);
     buffer.writeln(financialStanding);


### PR DESCRIPTION
- also adds padding to single event 
- and fixes grammar in msg to parents